### PR TITLE
URL Fingerprinting

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,8 @@
 import Config
 
 config :still,
-  view_helpers: []
+  view_helpers: [],
+  dev_layout: true,
+  url_fingerprinting: false
 
 import_config("#{Mix.env()}.exs")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,6 +1,8 @@
 import Config
 
 config :still,
+  dev_layout: false,
+  url_fingerprinting: true,
   base_url: "https://subvisual.github.io/still/",
   input: Path.join(Path.dirname(__DIR__), "priv/site"),
   output: Path.join(Path.dirname(__DIR__), "_site"),

--- a/lib/mix/tasks/still.compile.ex
+++ b/lib/mix/tasks/still.compile.ex
@@ -5,6 +5,9 @@ defmodule Mix.Tasks.Still.Compile do
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:still)
 
+    Application.put_env(:still, :url_fingerprinting, true)
+    Application.put_env(:still, :dev_layout, false)
+
     Still.Compiler.Traverse.run()
   end
 end

--- a/lib/still/compiler/file.ex
+++ b/lib/still/compiler/file.ex
@@ -10,7 +10,6 @@ defmodule Still.Compiler.File do
       file =
       %SourceFile{input_file: input_file}
       |> compile_file()
-      |> set_output_file()
 
     with new_file_path <- get_output_path(file),
          _ <- File.mkdir_p!(Path.dirname(new_file_path)),
@@ -73,23 +72,6 @@ defmodule Still.Compiler.File do
   rescue
     e in Preprocessor.SyntaxError ->
       handle_syntax_error(file, e)
-  end
-
-  def set_output_file(%{variables: %{permalink: permalink}} = file) do
-    %{file | output_file: permalink}
-  end
-
-  def set_output_file(%{input_file: input_file, extension: extension} = file)
-      when not is_nil(extension) do
-    output_file =
-      input_file
-      |> String.replace(Path.extname(input_file), extension)
-
-    %{file | output_file: output_file}
-  end
-
-  def set_output_file(%{input_file: input_file} = file) do
-    %{file | output_file: input_file}
   end
 
   defp handle_syntax_error(file, e) do

--- a/lib/still/compiler/file/content.ex
+++ b/lib/still/compiler/file/content.ex
@@ -11,7 +11,7 @@ defmodule Still.Compiler.File.Content do
     |> append_layout()
   end
 
-  @spec render(SourceFile.t(), any()) :: SourceFile.t()
+  @spec compile(SourceFile.t(), any()) :: SourceFile.t()
   def compile(file, preprocessors) do
     render(file, preprocessors)
     |> append_development_layout()

--- a/lib/still/compiler/incremental/node.ex
+++ b/lib/still/compiler/incremental/node.ex
@@ -29,7 +29,7 @@ defmodule Still.Compiler.Incremental.Node do
   alias Still.Compiler.PreprocessorError
   alias __MODULE__.Compile
 
-  @default_compilation_timeout 15_000
+  @default_compilation_timeout 5_000
 
   def start_link(file: file) do
     GenServer.start_link(__MODULE__, %{file: file}, name: file |> String.to_atom())

--- a/lib/still/compiler/view_helpers.ex
+++ b/lib/still/compiler/view_helpers.ex
@@ -7,7 +7,9 @@ defmodule Still.Compiler.ViewHelpers do
         Context,
         Incremental,
         ViewHelpers.Link,
-        ViewHelpers.UrlFor
+        ViewHelpers.UrlFor,
+        ViewHelpers.LinkToCSS,
+        ViewHelpers.LinkToJS
       }
 
       alias __MODULE__
@@ -63,6 +65,14 @@ defmodule Still.Compiler.ViewHelpers do
           })
 
         content
+      end
+
+      def link_to_css(path, opts \\ []) do
+        LinkToCSS.render(path, opts, @env)
+      end
+
+      def link_to_js(path, opts \\ []) do
+        LinkToJS.render(path, opts, @env)
       end
     end
   end

--- a/lib/still/compiler/view_helpers/link_to_css.ex
+++ b/lib/still/compiler/view_helpers/link_to_css.ex
@@ -1,0 +1,27 @@
+defmodule Still.Compiler.ViewHelpers.LinkToCSS do
+  alias Still.Compiler.Incremental
+  alias Still.Compiler.ViewHelpers.UrlFor
+
+  require Logger
+
+  @spec render(String.t(), list(any()), list(any())) :: String.t()
+  def render(file, opts, env) do
+    link_opts =
+      opts
+      |> Enum.map(fn {k, v} ->
+        "#{k}=#{v}"
+      end)
+      |> Enum.join(" ")
+
+    with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
+         %{output_file: output_file} <- Incremental.Node.render(pid, %{}, env[:input_file]) do
+      """
+      <link rel="stylesheet" #{link_opts} href=#{UrlFor.render(output_file)} />
+      """
+    else
+      _ ->
+        Logger.error("File process not found for #{file}")
+        ""
+    end
+  end
+end

--- a/lib/still/compiler/view_helpers/link_to_js.ex
+++ b/lib/still/compiler/view_helpers/link_to_js.ex
@@ -1,0 +1,26 @@
+defmodule Still.Compiler.ViewHelpers.LinkToJS do
+  alias Still.Compiler.Incremental
+  alias Still.Compiler.ViewHelpers.UrlFor
+
+  require Logger
+
+  def render(file, opts, env) do
+    link_opts =
+      opts
+      |> Enum.map(fn {k, v} ->
+        "#{k}=#{v}"
+      end)
+      |> Enum.join(" ")
+
+    with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
+         %{output_file: output_file} <- Incremental.Node.render(pid, %{}, env[:input_file]) do
+      """
+      <script #{link_opts} src=#{UrlFor.render(output_file)}></script>
+      """
+    else
+      _ ->
+        Logger.error("File process not found for #{file}")
+        ""
+    end
+  end
+end

--- a/lib/still/compiler/view_helpers/url_for.ex
+++ b/lib/still/compiler/view_helpers/url_for.ex
@@ -1,6 +1,7 @@
 defmodule Still.Compiler.ViewHelpers.UrlFor do
   import Still.Utils
 
+  @spec render(String.t()) :: String.t()
   def render(relative_path) do
     relative_path
     |> add_base_url()

--- a/lib/still/preprocessor/css_minify.ex
+++ b/lib/still/preprocessor/css_minify.ex
@@ -1,8 +1,12 @@
 defmodule Still.Preprocessor.CSSMinify do
   alias Still.Preprocessor
 
-  use Preprocessor, ext: ".css"
+  use Preprocessor
 
+  @impl true
+  def extension(_), do: ".css"
+
+  @impl true
   def render(%{content: content} = file) do
     content =
       content

--- a/lib/still/preprocessor/eex.ex
+++ b/lib/still/preprocessor/eex.ex
@@ -4,7 +4,10 @@ defmodule Still.Preprocessor.EEx do
   alias Still.Preprocessor
   alias Still.Preprocessor.EEx.Renderer
 
-  use Preprocessor, ext: ".html"
+  use Preprocessor
+
+  @impl true
+  def extension(_), do: ".html"
 
   @impl true
   def render(file) do

--- a/lib/still/preprocessor/js.ex
+++ b/lib/still/preprocessor/js.ex
@@ -1,8 +1,12 @@
 defmodule Still.Preprocessor.JS do
   alias Still.Preprocessor
 
-  use Preprocessor, ext: ".js"
+  use Preprocessor
 
+  @impl true
+  def extension(_), do: ".js"
+
+  @impl true
   def render(file) do
     file
   end

--- a/lib/still/preprocessor/markdown.ex
+++ b/lib/still/preprocessor/markdown.ex
@@ -1,8 +1,12 @@
 defmodule Still.Preprocessor.Markdown do
   alias Still.Preprocessor
 
-  use Preprocessor, ext: ".html"
+  use Preprocessor
 
+  @impl true
+  def extension(_), do: ".html"
+
+  @impl true
   def render(%{content: content} = file) do
     html_doc = Markdown.to_html(content, fenced_code: true, quote: true)
 

--- a/lib/still/preprocessor/output_path.ex
+++ b/lib/still/preprocessor/output_path.ex
@@ -1,0 +1,22 @@
+defmodule Still.Preprocessor.OutputPath do
+  alias Still.Preprocessor
+
+  use Preprocessor
+
+  @impl true
+  def render(%{variables: %{permalink: permalink}} = file) do
+    %{file | output_file: permalink}
+  end
+
+  def render(%{input_file: input_file, extension: extension} = file) do
+    output_file =
+      input_file
+      |> String.replace(Path.extname(input_file), extension)
+
+    %{file | output_file: output_file}
+  end
+
+  def render(%{input_file: input_file} = file) do
+    %{file | output_file: input_file}
+  end
+end

--- a/lib/still/preprocessor/slime.ex
+++ b/lib/still/preprocessor/slime.ex
@@ -4,7 +4,10 @@ defmodule Still.Preprocessor.Slime do
   alias Still.Preprocessor
   alias Still.Preprocessor.Slime.Renderer
 
-  use Preprocessor, ext: ".html"
+  use Preprocessor
+
+  @impl true
+  def extension(_), do: ".html"
 
   @impl true
   def render(file) do

--- a/lib/still/preprocessor/url_fingerprinting.ex
+++ b/lib/still/preprocessor/url_fingerprinting.ex
@@ -1,0 +1,35 @@
+defmodule Still.Preprocessor.URLFingerprinting do
+  alias Still.Preprocessor
+
+  use Preprocessor
+
+  @impl true
+  def render(%{output_file: nil} = file) do
+    file
+  end
+
+  @impl true
+  def render(file) do
+    if enabled?() do
+      do_render(file)
+    else
+      file
+    end
+  end
+
+  defp do_render(%{content: content, output_file: output_file} = file) do
+    hash =
+      :crypto.hash(:md5, content)
+      |> Base.url_encode64()
+
+    ext =
+      output_file
+      |> Path.extname()
+
+    %{file | output_file: String.replace_suffix(output_file, ext, "-#{hash}#{ext}")}
+  end
+
+  def enabled? do
+    Application.get_env(:still, :url_fingerprinting, false)
+  end
+end

--- a/priv/site/_layout.slime
+++ b/priv/site/_layout.slime
@@ -8,8 +8,8 @@ html
       = title
     meta charset="UTF-8"
     meta name="viewport" content="width=device-width, initial-scale=1.0"
-    link media="all" rel="stylesheet" href="#{url_for("/css/theme.css")}"
-    script src="#{url_for("/console.js")}"
+    = link_to_js "/console.js"
+    = link_to_css "/css/theme.css", media: "all"
   body
     = children
     = include("_includes/footer.slime")

--- a/priv/site/console.js
+++ b/priv/site/console.js
@@ -1,1 +1,1 @@
-console.log("Hello there!");
+console.log("Hello world");

--- a/priv/site/index.slime
+++ b/priv/site/index.slime
@@ -15,3 +15,5 @@ layout: _layout.slime
     = Enum.map get_collections("post"), fn post ->
       li
         = link post[:variables][:title], to: post[:output_file]
+
+= link_to_js "console.js"

--- a/templates/config/config.exs
+++ b/templates/config/config.exs
@@ -3,3 +3,5 @@ import Config
 config :still,
   input: Path.join(Path.dirname(__DIR__), "priv/site"),
   output: Path.join(Path.dirname(__DIR__), "_site")
+
+import_config("#{Mix.env()}.exs")

--- a/templates/config/prod.exs
+++ b/templates/config/prod.exs
@@ -1,0 +1,7 @@
+import Config
+
+config :still,
+  dev_layout: false,
+  url_fingerprinting: true,
+  # change this to your production endpoint
+  base_url: raise(":base_url not set")

--- a/test/still/compiler/preprocessor_test.exs
+++ b/test/still/compiler/preprocessor_test.exs
@@ -4,7 +4,11 @@ defmodule Still.PreprocessorTest do
   alias Still.{Preprocessor, SourceFile}
 
   defmodule TestPreprocessorWithExt do
-    use Preprocessor, ext: ".css"
+    use Preprocessor
+
+    def extension(_) do
+      ".css"
+    end
 
     def render(file) do
       file


### PR DESCRIPTION
URL fingerprinting is important for caching in production. In this change we move the code to calculate the output path to a new preprocessor, and we add another preprocessor to add the fingerprint to the output path. There's also a config to enable this feature when running the task `compile`.

There are also two new helpers to link to css and js files built on top of this.