### PR TITLE
Simpler solution for user view helpers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,6 @@
 import Config
 
+config :still,
+  view_helpers: []
+
 import_config("#{Mix.env()}.exs")

--- a/lib/still/preprocessor/renderer.ex
+++ b/lib/still/preprocessor/renderer.ex
@@ -89,25 +89,12 @@ defmodule Still.Preprocessor.Renderer do
       end
 
       defp user_view_helpers_asts do
-        :code.all_available()
-        |> Stream.map(fn {mod, _, _} -> :"#{mod}" end)
-        |> Stream.map(fn mod ->
-          try do
-            {mod, mod.module_info(:attributes)[:behaviour] || []}
-          rescue
-            UndefinedFunctionError ->
-              nil
+        Application.get_env(:still, :view_helpers, [])
+        |> Enum.map(fn module ->
+          quote do
+            import unquote(module)
           end
         end)
-        |> Stream.filter(& &1)
-        |> Stream.map(fn {module, behaviours} ->
-          if Still.ViewHelper in behaviours do
-            quote do
-              import unquote(module)
-            end
-          end
-        end)
-        |> Enum.filter(& &1)
       end
 
       defp ensure_current_context(variables) do

--- a/priv/site/documentation.md
+++ b/priv/site/documentation.md
@@ -136,10 +136,11 @@ Sometimes you want to alter the file name or path but keep the content of the fi
 ```elixir
 config :still,
   pass_through_copy: [css: "styles"]
-  
+
   # this is also valid:
   # config :still,
   #   pass_through_copy: [{"css", "styles"}]
+```
 
 In the example above, the `css` folder from the input folder but will be renamed to `styles` in the output folder.
 
@@ -205,16 +206,26 @@ html
     = include "_includes/head.slim"
   body
     = children
+```
 
 ### Link to other files
 
 In any file you can call the `link` function to create a link to somewhere
-else. This function will already take care of specifying the `rel` and `target`
-when necessary. It supports both relative and absolute paths:
+else. This function will already take care of specifying the `rel` and `target` when necessary. It supports both relative and absolute paths:
 
 ```slim
 = link "Home", to: "/"
 = link "Blog", to: "https://example.org"
+```
+
+### Custom view helpers
+
+To call your own functions from the view files, register a module in the config:
+
+```elixir
+config :still,
+  view_helpers: [Your.Module]
+```
 
 ## License
 


### PR DESCRIPTION
With this change, we replace the existing mechanism to load the user's view helpers. Up until now, the modules would be imported if they implemented a specific behavior. Unfortunately, this mechanism slows down the compilation, and it's noticeable on our small website. This may be our fault for lacking the knowledge to come up with a better solution, but for now, simply having the users declare in the config file which modules are the view helpers saves us this trouble.

This change fixes https://github.com/subvisual/still/issues/41