### PR TITLE
Remove Still.Preprocessor.SyntaxError

### DIFF
--- a/lib/still/compiler/file.ex
+++ b/lib/still/compiler/file.ex
@@ -48,7 +48,7 @@ defmodule Still.Compiler.File do
     with {:ok, content} <- File.read(get_input_path(file)),
          file <- %SourceFile{file | content: content},
          {:ok, preprocessor} <- Preprocessor.for(file) do
-      compile_content(file, preprocessor)
+      Compiler.File.Content.compile(file, preprocessor)
     end
   end
 
@@ -56,31 +56,7 @@ defmodule Still.Compiler.File do
     with {:ok, content} <- File.read(get_input_path(file)),
          file <- %SourceFile{file | content: content},
          {:ok, preprocessor} <- Preprocessor.for(file) do
-      render_content(file, preprocessor)
+      Compiler.File.Content.render(file, preprocessor)
     end
-  end
-
-  defp compile_content(file, preprocessor) do
-    Compiler.File.Content.compile(file, preprocessor)
-  rescue
-    e in Preprocessor.SyntaxError ->
-      handle_syntax_error(file, e)
-  end
-
-  defp render_content(file, preprocessor) do
-    Compiler.File.Content.render(file, preprocessor)
-  rescue
-    e in Preprocessor.SyntaxError ->
-      handle_syntax_error(file, e)
-  end
-
-  defp handle_syntax_error(file, e) do
-    Logger.error("Syntax error in #{file}\n#{e.line_number}: #{e.line}\n#{e.message}",
-      file: file,
-      line: e.line_number,
-      crash_reason: e.message
-    )
-
-    {:error, :syntax_error}
   end
 end

--- a/lib/still/compiler/file/content.ex
+++ b/lib/still/compiler/file/content.ex
@@ -59,12 +59,26 @@ defmodule Still.Compiler.File.Content do
     preprocessor.run(file)
     |> render_template(remaining_preprocessors)
   catch
-    :error, %CompileError{description: description} ->
+    :error, %{description: description} ->
       raise PreprocessorError,
         message: description,
         preprocessor: preprocessor,
         remaining_preprocessors: remaining_preprocessors,
         source_file: file,
         stacktrace: __STACKTRACE__
+
+    :error, e ->
+      case e do
+        %PreprocessorError{} ->
+          raise e
+
+        _ ->
+          raise PreprocessorError,
+            message: inspect(e),
+            preprocessor: preprocessor,
+            remaining_preprocessors: remaining_preprocessors,
+            source_file: file,
+            stacktrace: __STACKTRACE__
+      end
   end
 end

--- a/lib/still/compiler/preprocessor_error.ex
+++ b/lib/still/compiler/preprocessor_error.ex
@@ -95,7 +95,7 @@ defmodule Still.Compiler.PreprocessorError do
     extension =
       preprocessors
       |> Enum.reduce(Path.extname(input_file), fn p, acc ->
-        p.extension() || acc
+        p.extension(source_file) || acc
       end)
 
     %{source_file | extension: extension}

--- a/lib/still/preprocessor/eex.ex
+++ b/lib/still/preprocessor/eex.ex
@@ -12,13 +12,6 @@ defmodule Still.Preprocessor.EEx do
   @impl true
   def render(file) do
     %{file | content: do_render(file)}
-  rescue
-    e in EEx.SyntaxError ->
-      raise Preprocessor.SyntaxError,
-        message: e.message,
-        line_number: e.line_number,
-        column: e.column,
-        line: ""
   end
 
   defp do_render(%{variables: variables} = file) do

--- a/lib/still/preprocessor/syntax_error.ex
+++ b/lib/still/preprocessor/syntax_error.ex
@@ -1,3 +1,0 @@
-defmodule Still.Preprocessor.SyntaxError do
-  defexception [:line, :line_number, :message, :column]
-end


### PR DESCRIPTION
In 71c4af5089cc13352a7df932abb640092bb62b25 we created a new mechanism
to handle errors in the preprocessors: instead of exiting the
application, we catch the exceptions, turn them into
%PreprocessorError{} and then turn those exceptions into an error
overlay that we show to the users. Still, some errors are being handled
by the previous mechanism that turns errors into SyntaxError and logs
them to the console. In this change, we remove this old mechanism so that
every error goes straight to the error overlay, informing the user.