### PR TITLE
Add CompilationQueue

### DIFF
--- a/lib/mix/tasks/still.compile.ex
+++ b/lib/mix/tasks/still.compile.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Still.Compile do
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:still)
 
-    Still.Compiler.CompilationQueue.subscribe()
+    Still.Compiler.CompilationStage.subscribe()
 
     Application.put_env(:still, :url_fingerprinting, true)
     Application.put_env(:still, :dev_layout, false)

--- a/lib/mix/tasks/still.compile.ex
+++ b/lib/mix/tasks/still.compile.ex
@@ -5,9 +5,17 @@ defmodule Mix.Tasks.Still.Compile do
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:still)
 
+    Still.Compiler.CompilationQueue.subscribe()
+
     Application.put_env(:still, :url_fingerprinting, true)
     Application.put_env(:still, :dev_layout, false)
 
     Still.Compiler.Traverse.run()
+
+    receive do
+      :bus_empty -> :ok
+    after
+      :infinity -> :error
+    end
   end
 end

--- a/lib/still/compiler/collections.ex
+++ b/lib/still/compiler/collections.ex
@@ -1,7 +1,7 @@
 defmodule Still.Compiler.Collections do
   use GenServer
 
-  alias Still.Compiler.CompilationQueue
+  alias Still.Compiler.CompilationStage
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
@@ -69,7 +69,7 @@ defmodule Still.Compiler.Collections do
     |> Map.get(:tag, [])
     |> Enum.map(fn tag ->
       Map.get(state.subscribers, tag, [])
-      |> CompilationQueue.compile()
+      |> CompilationStage.compile()
     end)
   end
 end

--- a/lib/still/compiler/collections.ex
+++ b/lib/still/compiler/collections.ex
@@ -16,7 +16,7 @@ defmodule Still.Compiler.Collections do
   end
 
   def add(file) do
-    GenServer.call(__MODULE__, {:add, file |> Map.from_struct()}, :infinity)
+    GenServer.call(__MODULE__, {:add, file |> Map.from_struct()})
   end
 
   def init(_) do

--- a/lib/still/compiler/collections.ex
+++ b/lib/still/compiler/collections.ex
@@ -1,10 +1,14 @@
 defmodule Still.Compiler.Collections do
   use GenServer
 
-  alias Still.Compiler.Incremental
+  alias Still.Compiler.CompilationQueue
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  def reset do
+    GenServer.call(__MODULE__, :reset)
   end
 
   def get(collection, parent_file) do
@@ -12,19 +16,23 @@ defmodule Still.Compiler.Collections do
   end
 
   def add(file) do
-    GenServer.cast(__MODULE__, {:add, file |> Map.from_struct()})
+    GenServer.call(__MODULE__, {:add, file |> Map.from_struct()}, :infinity)
   end
 
   def init(_) do
     {:ok, %{files: [], subscribers: %{}}}
   end
 
-  def handle_cast({:add, file}, state) do
+  def handle_call({:add, file}, _, state) do
     notify_subscribers(file, state)
 
     files = insert_file(file, state.files)
 
-    {:noreply, %{state | files: files}}
+    {:reply, :ok, %{state | files: files}}
+  end
+
+  def handle_call(:reset, _from, _state) do
+    {:reply, :ok, %{files: [], subscribers: %{}}}
   end
 
   def handle_call({:get, collection, parent_file}, _from, state) do
@@ -60,11 +68,8 @@ defmodule Still.Compiler.Collections do
     |> Map.get(:variables)
     |> Map.get(:tag, [])
     |> Enum.map(fn tag ->
-      Task.start(fn ->
-        Map.get(state.subscribers, tag, [])
-        |> Enum.map(&Incremental.Registry.get_or_create_file_process/1)
-        |> Enum.map(&Incremental.Node.compile/1)
-      end)
+      Map.get(state.subscribers, tag, [])
+      |> CompilationQueue.compile()
     end)
   end
 end

--- a/lib/still/compiler/compilation_queue.ex
+++ b/lib/still/compiler/compilation_queue.ex
@@ -1,0 +1,117 @@
+defmodule Still.Compiler.CompilationQueue do
+  @moduledoc """
+  There are many events that lead to a file being compiled:
+
+  * when Still starts, all files are compiled;
+  * files that change are compiled;
+  * files that include files that have changed are compiled;
+  * any many more.
+
+  Every compilation request goes through the `CompilationQueue`. Subscribers
+  to this process are notified when the queue is empty, which is usefull to
+  refresh the browser or finish the compilation task in production.
+  """
+  use GenServer
+
+  alias Still.Compiler.Incremental
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  def compile(file) do
+    GenServer.cast(__MODULE__, {:compile, file})
+  end
+
+  def subscribe do
+    GenServer.call(__MODULE__, :subscribe)
+  end
+
+  def unsubscribe do
+    GenServer.call(__MODULE__, :unsubscribe)
+  end
+
+  def init(_) do
+    {:ok, %{to_compile: [], subscribers: [], changed: false, timer: nil}}
+  end
+
+  def handle_call(:subscribe, {from, _}, state) do
+    [from | state.subscribers] |> Enum.uniq()
+
+    {:reply, :ok, %{state | subscribers: [from | state.subscribers] |> Enum.uniq()}}
+  end
+
+  def handle_call(:unsubscribe, {from, _}, state) do
+    [from | state.subscribers] |> Enum.uniq()
+
+    {:reply, :ok, %{state | subscribers: state.subscribers |> Enum.reject(&(&1 == from))}}
+  end
+
+  def handle_cast({:compile, files}, state) when is_list(files) do
+    if state.timer do
+      Process.cancel_timer(state.timer)
+    end
+
+    {:noreply,
+     %{
+       state
+       | to_compile: Enum.concat(files, state.to_compile),
+         timer: Process.send_after(self(), :run, 100)
+     }}
+  end
+
+  def handle_cast({:compile, file}, state) do
+    if state.timer do
+      Process.cancel_timer(state.timer)
+    end
+
+    {:noreply,
+     %{
+       state
+       | to_compile: [file | state.to_compile],
+         timer: Process.send_after(self(), :run, 100)
+     }}
+  end
+
+  def handle_info(:run, %{to_compile: [], changed: true} = state) do
+    state.subscribers
+    |> Enum.each(fn pid ->
+      send(pid, :bus_empty)
+    end)
+
+    {:noreply, %{state | changed: false, timer: nil}}
+  end
+
+  def handle_info(:run, %{to_compile: []} = state) do
+    {:noreply, %{state | timer: nil}}
+  end
+
+  def handle_info(:run, state) do
+    state.to_compile
+    |> Enum.uniq()
+    |> Enum.map(fn file ->
+      Task.async(fn ->
+        compile_file(file)
+      end)
+    end)
+    |> Enum.map(&Task.await/1)
+
+    Process.send_after(self(), :run, 900)
+
+    {:noreply, %{state | to_compile: [], changed: true, timer: nil}}
+  end
+
+  defp compile_file("."), do: :ok
+
+  defp compile_file(file) do
+    Incremental.Registry.get_or_create_file_process(file)
+    |> Incremental.Node.compile()
+    |> case do
+      :ok ->
+        :ok
+
+      _ ->
+        file |> Path.dirname() |> compile_file()
+    end
+  end
+end

--- a/lib/still/compiler/compilation_stage.ex
+++ b/lib/still/compiler/compilation_stage.ex
@@ -1,4 +1,4 @@
-defmodule Still.Compiler.CompilationQueue do
+defmodule Still.Compiler.CompilationStage do
   @moduledoc """
   There are many events that lead to a file being compiled:
 
@@ -7,7 +7,7 @@ defmodule Still.Compiler.CompilationQueue do
   * files that include files that have changed are compiled;
   * any many more.
 
-  Every compilation request goes through the `CompilationQueue`. Subscribers
+  Every compilation request goes through the `CompilationStage`. Subscribers
   to this process are notified when the queue is empty, which is usefull to
   refresh the browser or finish the compilation task in production.
   """

--- a/lib/still/compiler/incremental/node.ex
+++ b/lib/still/compiler/incremental/node.ex
@@ -24,7 +24,6 @@ defmodule Still.Compiler.Incremental.Node do
 
   use GenServer
 
-  alias Still.Web.BrowserSubscriptions
   alias Still.Compiler
   alias Still.Compiler.PreprocessorError
   alias Still.Compiler.ErrorCache
@@ -66,7 +65,6 @@ defmodule Still.Compiler.Incremental.Node do
   @impl true
   def handle_call(:compile, _from, state) do
     with {:ok, source_file} <- Compile.run(state) do
-      BrowserSubscriptions.notify()
       ErrorCache.set({:ok, source_file})
       {:reply, source_file, state}
     else
@@ -76,7 +74,6 @@ defmodule Still.Compiler.Incremental.Node do
   catch
     :error, %PreprocessorError{} = e ->
       ErrorCache.set({:error, e})
-      BrowserSubscriptions.notify()
 
       {:reply, :ok, state}
   end

--- a/lib/still/compiler/incremental/node/compile.ex
+++ b/lib/still/compiler/incremental/node/compile.ex
@@ -1,7 +1,8 @@
 defmodule Still.Compiler.Incremental.Node.Compile do
   import Still.Utils
 
-  alias Still.{Compiler, Compiler.Incremental, Compiler.PassThroughCopy}
+  alias Still.Compiler
+  alias Still.Compiler.{Incremental, PassThroughCopy, CompilationQueue}
 
   def run(state) do
     with :ok <- try_pass_through_copy(state) do
@@ -39,11 +40,8 @@ defmodule Still.Compiler.Incremental.Node.Compile do
   end
 
   defp notify_subscribers(state) do
-    Task.start(fn ->
-      state.subscribers
-      |> Enum.map(&Incremental.Registry.get_or_create_file_process/1)
-      |> Enum.map(&Incremental.Node.compile/1)
-    end)
+    state.subscribers
+    |> CompilationQueue.compile()
   end
 
   defp should_be_ignored?(file) do

--- a/lib/still/compiler/incremental/node/compile.ex
+++ b/lib/still/compiler/incremental/node/compile.ex
@@ -2,7 +2,7 @@ defmodule Still.Compiler.Incremental.Node.Compile do
   import Still.Utils
 
   alias Still.Compiler
-  alias Still.Compiler.{Incremental, PassThroughCopy, CompilationQueue}
+  alias Still.Compiler.{Incremental, PassThroughCopy, CompilationStage}
 
   def run(state) do
     with :ok <- try_pass_through_copy(state) do
@@ -41,7 +41,7 @@ defmodule Still.Compiler.Incremental.Node.Compile do
 
   defp notify_subscribers(state) do
     state.subscribers
-    |> CompilationQueue.compile()
+    |> CompilationStage.compile()
   end
 
   defp should_be_ignored?(file) do

--- a/lib/still/compiler/supervisor.ex
+++ b/lib/still/compiler/supervisor.ex
@@ -13,7 +13,8 @@ defmodule Still.Compiler.Supervisor do
       Compiler.Collections,
       Compiler.Context.Registry,
       Compiler.Incremental.Registry,
-      Compiler.ErrorCache
+      Compiler.ErrorCache,
+      Compiler.CompilationQueue
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/still/compiler/supervisor.ex
+++ b/lib/still/compiler/supervisor.ex
@@ -14,7 +14,7 @@ defmodule Still.Compiler.Supervisor do
       Compiler.Context.Registry,
       Compiler.Incremental.Registry,
       Compiler.ErrorCache,
-      Compiler.CompilationQueue
+      Compiler.CompilationStage
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/still/compiler/traverse.ex
+++ b/lib/still/compiler/traverse.ex
@@ -1,9 +1,11 @@
 defmodule Still.Compiler.Traverse do
   import Still.Utils
 
-  alias Still.Compiler.Incremental
+  alias Still.Compiler.{Incremental, CompilationQueue}
 
   def run() do
+    Still.Compiler.Collections.reset()
+
     with true <- File.dir?(get_input_path()),
          _ <- File.rmdir(get_output_path()),
          :ok <- File.mkdir_p(get_output_path()) do
@@ -38,8 +40,6 @@ defmodule Still.Compiler.Traverse do
   end
 
   defp process_file(file) do
-    file
-    |> Incremental.Registry.get_or_create_file_process()
-    |> Incremental.Node.compile()
+    file |> CompilationQueue.compile()
   end
 end

--- a/lib/still/compiler/traverse.ex
+++ b/lib/still/compiler/traverse.ex
@@ -1,7 +1,7 @@
 defmodule Still.Compiler.Traverse do
   import Still.Utils
 
-  alias Still.Compiler.{Incremental, CompilationQueue}
+  alias Still.Compiler.{Incremental, CompilationStage}
 
   def run() do
     Still.Compiler.Collections.reset()
@@ -40,6 +40,6 @@ defmodule Still.Compiler.Traverse do
   end
 
   defp process_file(file) do
-    file |> CompilationQueue.compile()
+    file |> CompilationStage.compile()
   end
 end

--- a/lib/still/watcher.ex
+++ b/lib/still/watcher.ex
@@ -2,7 +2,7 @@ defmodule Still.Watcher do
   use GenServer
 
   alias Still.Compiler
-  alias Still.Compiler.Incremental
+  alias Still.Compiler.{Incremental, CompilationQueue}
 
   import Still.Utils
 
@@ -57,20 +57,6 @@ defmodule Still.Watcher do
 
   defp process_file(file) do
     get_relative_input_path(file)
-    |> compile_file()
-  end
-
-  defp compile_file("."), do: :ok
-
-  defp compile_file(file) do
-    Incremental.Registry.get_or_create_file_process(file)
-    |> Incremental.Node.compile()
-    |> case do
-      {:ok, _} ->
-        :ok
-
-      _ ->
-        file |> Path.dirname() |> compile_file()
-    end
+    |> CompilationQueue.compile()
   end
 end

--- a/lib/still/watcher.ex
+++ b/lib/still/watcher.ex
@@ -2,7 +2,7 @@ defmodule Still.Watcher do
   use GenServer
 
   alias Still.Compiler
-  alias Still.Compiler.{Incremental, CompilationQueue}
+  alias Still.Compiler.{Incremental, CompilationStage}
 
   import Still.Utils
 
@@ -57,6 +57,6 @@ defmodule Still.Watcher do
 
   defp process_file(file) do
     get_relative_input_path(file)
-    |> CompilationQueue.compile()
+    |> CompilationStage.compile()
   end
 end

--- a/lib/still/web/browser_subscriptions.ex
+++ b/lib/still/web/browser_subscriptions.ex
@@ -1,6 +1,8 @@
 defmodule Still.Web.BrowserSubscriptions do
   use GenServer
 
+  alias Still.Compiler.CompilationQueue
+
   def start_link(_) do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
@@ -9,11 +11,8 @@ defmodule Still.Web.BrowserSubscriptions do
     GenServer.cast(__MODULE__, {:add, pid})
   end
 
-  def notify do
-    GenServer.cast(__MODULE__, :notify)
-  end
-
   def init(_) do
+    Process.send_after(self(), :subscribe, 100)
     {:ok, %{subscribers: [], timer_ref: nil}}
   end
 
@@ -21,20 +20,15 @@ defmodule Still.Web.BrowserSubscriptions do
     {:noreply, %{state | subscribers: [pid | state.subscribers]}}
   end
 
-  def handle_cast(:notify, state) do
-    if not is_nil(state.timer_ref) do
-      Process.cancel_timer(state.timer_ref)
-    end
-
-    timer_ref = Process.send_after(self(), :notify_subscribers, 800)
-
-    {:noreply, %{state | timer_ref: timer_ref}}
-  end
-
-  def handle_info(:notify_subscribers, state) do
+  def handle_info(:bus_empty, state) do
     state.subscribers
     |> Enum.each(&send(&1, Jason.encode!(%{type: "reload"})))
 
+    {:noreply, state}
+  end
+
+  def handle_info(:subscribe, state) do
+    CompilationQueue.subscribe()
     {:noreply, state}
   end
 end

--- a/lib/still/web/browser_subscriptions.ex
+++ b/lib/still/web/browser_subscriptions.ex
@@ -1,7 +1,7 @@
 defmodule Still.Web.BrowserSubscriptions do
   use GenServer
 
-  alias Still.Compiler.CompilationQueue
+  alias Still.Compiler.CompilationStage
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
@@ -28,7 +28,7 @@ defmodule Still.Web.BrowserSubscriptions do
   end
 
   def handle_info(:subscribe, state) do
-    CompilationQueue.subscribe()
+    CompilationStage.subscribe()
     {:noreply, state}
   end
 end

--- a/test/still/compiler/collections_test.exs
+++ b/test/still/compiler/collections_test.exs
@@ -3,10 +3,16 @@ defmodule Still.Compiler.CollectionsTest do
 
   import Mock
 
-  alias Still.{Compiler.Collections, SourceFile, Compiler.Incremental.Registry}
+  alias Still.{
+    Compiler.Collections,
+    SourceFile,
+    Compiler.Incremental.Registry,
+    Compiler.CompilationQueue
+  }
 
   setup do
     {:ok, _pid} = Collections.start_link(%{})
+    {:ok, _pid} = CompilationQueue.start_link(%{})
 
     :ok
   end
@@ -30,7 +36,7 @@ defmodule Still.Compiler.CollectionsTest do
 
         Collections.add(file)
 
-        assert_receive {_, _, :compile}
+        assert_receive {_, _, :compile}, 200
       end
     end
   end

--- a/test/still/compiler/collections_test.exs
+++ b/test/still/compiler/collections_test.exs
@@ -7,12 +7,12 @@ defmodule Still.Compiler.CollectionsTest do
     Compiler.Collections,
     SourceFile,
     Compiler.Incremental.Registry,
-    Compiler.CompilationQueue
+    Compiler.CompilationStage
   }
 
   setup do
     {:ok, _pid} = Collections.start_link(%{})
-    {:ok, _pid} = CompilationQueue.start_link(%{})
+    {:ok, _pid} = CompilationStage.start_link(%{})
 
     :ok
   end

--- a/test/still/compiler/incremental/node_test.exs
+++ b/test/still/compiler/incremental/node_test.exs
@@ -3,12 +3,12 @@ defmodule Still.Compiler.Incremental.NodeTest do
 
   alias Still.Compiler.Collections
   alias Still.Compiler.Incremental.{Registry, Node}
-  alias Still.Compiler.CompilationQueue
+  alias Still.Compiler.CompilationStage
 
   setup do
     {:ok, _pid} = Collections.start_link(%{})
     {:ok, _pid} = Registry.start_link(%{})
-    {:ok, _pid} = CompilationQueue.start_link(%{})
+    {:ok, _pid} = CompilationStage.start_link(%{})
 
     :ok
   end

--- a/test/still/compiler/incremental/node_test.exs
+++ b/test/still/compiler/incremental/node_test.exs
@@ -3,10 +3,12 @@ defmodule Still.Compiler.Incremental.NodeTest do
 
   alias Still.Compiler.Collections
   alias Still.Compiler.Incremental.{Registry, Node}
+  alias Still.Compiler.CompilationQueue
 
   setup do
     {:ok, _pid} = Collections.start_link(%{})
     {:ok, _pid} = Registry.start_link(%{})
+    {:ok, _pid} = CompilationQueue.start_link(%{})
 
     :ok
   end
@@ -27,7 +29,7 @@ defmodule Still.Compiler.Incremental.NodeTest do
 
       Node.compile(pid)
 
-      assert_receive {_, _, :compile}
+      assert_receive {_, _, :compile}, 200
     end
   end
 


### PR DESCRIPTION
The _CompilationStage_ is a new mechanism that compiles, and recompiles, files:

* the `Traverse` goes through the file system adding files to the _CompilationStage_.
* the `Watcher` adds changed files to the _CompilationStage_.
* when the `Node` recompiles, it adds its dependencies to the _CompilationStage_.

Because the _CompilationStage_ knows which files are pending compilation, we use it o inform the browser to refresh, or the compilation task to complete. Unfortunately, the compilation should be a little slower, but I cannot think of another solution right now.