### PR TITLE
The include function allows for variables as a map or keyword list

### DIFF
--- a/priv/site/index.slime
+++ b/priv/site/index.slime
@@ -2,7 +2,7 @@
 layout: _layout.slime
 ---
 
-= include("_includes/header.slime", %{header_title: false})
+= include("_includes/header.slime", header_title: false)
 
 .main
   h1.fancy-title Still

--- a/test/fixture/site/_includes/variables.slime
+++ b/test/fixture/site/_includes/variables.slime
@@ -1,0 +1,1 @@
+nav This include has variables: #{variable}

--- a/test/still/compiler/view_helpers_test.exs
+++ b/test/still/compiler/view_helpers_test.exs
@@ -1,0 +1,41 @@
+defmodule Still.Compiler.ViewHelpersTest do
+  use Still.Case
+
+  alias Still.Compiler.{ViewHelpers, Incremental}
+  alias Still.Compiler.Incremental.Node
+
+  defmodule View do
+    use ViewHelpers
+  end
+
+  setup do
+    {:ok, _pid} = Incremental.Registry.start_link(%{})
+
+    :ok
+  end
+
+  describe "include/2" do
+    test "renders a file" do
+      file = "_includes/header.slime"
+
+      assert "<header><p>This is a header</p></header>" == View.include(file)
+    end
+
+    test "variables can be a map or a keyword list" do
+      file = "_includes/variables.slime"
+
+      assert "<nav>This include has variables: Test</nav>" == View.include(file, variable: "Test")
+
+      assert "<nav>This include has variables: Test</nav>" ==
+               View.include(file, %{variable: "Test"})
+    end
+
+    test "adds a subscription to the included file" do
+      file = "_includes/header.slime"
+
+      View.include(file)
+
+      assert_receive {_, {:add_subscription, file}}
+    end
+  end
+end


### PR DESCRIPTION
It makes the API so much nicer.