### PR TITLE
Fix the development layout when still is in deps

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@ import Config
 
 config :still,
   view_helpers: [],
-  dev_layout: true,
+  dev_layout: false,
   url_fingerprinting: false
 
 import_config("#{Mix.env()}.exs")

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,6 +1,7 @@
 import Config
 
 config :still,
+  dev_layout: true,
   base_url: "http://localhost:3000",
   input: Path.join(Path.dirname(__DIR__), "priv/site"),
   output: Path.join(Path.dirname(__DIR__), "_site"),

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,6 @@
 import Config
 
 config :still,
-  dev_layout: false,
   url_fingerprinting: true,
   base_url: "https://subvisual.github.io/still/",
   input: Path.join(Path.dirname(__DIR__), "priv/site"),

--- a/installer/templates/config/config.exs
+++ b/installer/templates/config/config.exs
@@ -1,6 +1,7 @@
 import Config
 
 config :still,
+  dev_layout: false,
   input: Path.join(Path.dirname(__DIR__), "priv/site"),
   output: Path.join(Path.dirname(__DIR__), "_site")
 

--- a/installer/templates/config/prod.exs
+++ b/installer/templates/config/prod.exs
@@ -1,7 +1,6 @@
 import Config
 
 config :still,
-  dev_layout: false,
   url_fingerprinting: true,
   # change this to your production endpoint
   base_url: raise(":base_url not set")

--- a/lib/still/compiler/file/content.ex
+++ b/lib/still/compiler/file/content.ex
@@ -39,16 +39,14 @@ defmodule Still.Compiler.File.Content do
 
   defp append_layout(file), do: file
 
-  if Mix.env() == :dev do
-    defp append_development_layout(%{extension: ".html", content: content} = file) do
+  defp append_development_layout(%{extension: ".html", content: content} = file) do
+    if Application.get_env(:still, :dev_layout, false) do
       %{content: content} = Still.Compiler.File.DevLayout.wrap(content)
 
       %{file | content: content}
+    else
+      file
     end
-  end
-
-  defp append_development_layout(file) do
-    file
   end
 
   defp render_template(file, []) do

--- a/templates/config/dev.exs
+++ b/templates/config/dev.exs
@@ -1,4 +1,2 @@
-import Config
-
 config :still,
   dev_layout: true


### PR DESCRIPTION
Dependencies are always compiled in :prod, which means that we are
buiding a website using still, we never get to use the development
layout.