### PR TITLE
Template variables are now module variables

### DIFF
--- a/lib/still/preprocessor/eex.ex
+++ b/lib/still/preprocessor/eex.ex
@@ -20,6 +20,6 @@ defmodule Still.Preprocessor.EEx do
       |> Map.put(:input_file, Map.get(file, :input_file))
 
     Renderer.create(%{file | variables: variables})
-    |> apply(:render, variables |> Map.values())
+    |> apply(:render, [])
   end
 end

--- a/lib/still/preprocessor/slime.ex
+++ b/lib/still/preprocessor/slime.ex
@@ -27,6 +27,6 @@ defmodule Still.Preprocessor.Slime do
       |> Map.put(:input_file, Map.get(file, :input_file))
 
     Renderer.create(%{file | variables: variables})
-    |> apply(:render, variables |> Map.values())
+    |> apply(:render, [])
   end
 end

--- a/priv/site/_includes/header.slime
+++ b/priv/site/_includes/header.slime
@@ -3,7 +3,7 @@ header_title: true
 ---
 
 header.header
-  = if header_title do
+  = if @header_title do
     = link "Still", to: "/"
   - else
     div

--- a/priv/site/_layout.slime
+++ b/priv/site/_layout.slime
@@ -5,11 +5,11 @@ doctype html
 html
   head
     title
-      = title
+      = @title
     meta charset="UTF-8"
     meta name="viewport" content="width=device-width, initial-scale=1.0"
     = link_to_js "/console.js"
     = link_to_css "/css/theme.css", media: "all"
   body
-    = children
+    = @children
     = include("_includes/footer.slime")

--- a/priv/site/_post_layout.slime
+++ b/priv/site/_post_layout.slime
@@ -4,7 +4,8 @@ layout: _layout.slime
 = include("_includes/header.slime")
 
 h1.fancy-title
-  = title
+  = @title
 
-.main
-  = children
+= if assigns[:children] do
+  .main
+    = @children

--- a/priv/still/dev.slime
+++ b/priv/still/dev.slime
@@ -1,4 +1,4 @@
-= children
+= @children
 
 javascript:
   window.socket = new WebSocket('ws://' + location.host + '/ws');

--- a/test/fixture/site/_includes/variables.slime
+++ b/test/fixture/site/_includes/variables.slime
@@ -1,1 +1,1 @@
-nav This include has variables: #{variable}
+nav This include has variables: #{@variable}

--- a/test/fixture/site/_layout.slime
+++ b/test/fixture/site/_layout.slime
@@ -4,8 +4,8 @@ title: "Still"
 doctype html
 html
   head
-    title #{title || "Still"}
+    title #{@title || "Still"}
     meta name="viewport" content="width=device-width, initial-scale=1.0"
     link media="all" rel="stylesheet" href="css/theme.css"
   body
-    = children
+    = @children

--- a/test/still/compiler/preprocessor/slime_test.exs
+++ b/test/still/compiler/preprocessor/slime_test.exs
@@ -15,7 +15,7 @@ defmodule Still.Preprocessor.SlimeTest do
     end
 
     test "passes variables to the template" do
-      slime = "p = title"
+      slime = "p = @title"
       input_file = "index.slime"
       title = "This is a test"
 


### PR DESCRIPTION
With this change, every variable is available as a module variable instead of as a function variable.

This template:

```
---
title: "Titlte"
---
h1 = title
```

Becomes this

```
---
title: "Titlte"
---
h1 = @title
```

This is what happens in Phoenix, and I think I know why. Storytime!

---

There's a blog, and each entry is like this:

```
---
layout: _layout.slime
---
h1 Some title.
```

And the layout is like this:

```
.nav
  a Link1
  a Link2

= children
```

But in some pages, we want to hide the nav:

```
---
layout: _layout.slime
hide_anv: true
---
h1 Some title.
```

And on the layout we should be able to do something like this:

```
= if !hide_nav do
  .nav
    a Link1
    a Link2

= children
```

Unfortunately, it doesn't because for the entries that don't hide the nav the variable is not set. So I could either add it to every entry, which is a mess or define a default value:

```
---
hide_layout: false
---
= if !hide_nav do
  .nav
    a Link1
    a Link2

= children
```

But this solution doesn't work for complex variables like maps. You can't set a default value for a map (you can, but it's a mess). That's where the `assigns` map you have in Phoenix comes in:


```
= if Map.get(assigns, :hide_nav, false) do
  .nav
    a Link1
    a Link2

= children
```

And that's why I'm making this change. I don't know if Phoenix works this way for this reason, but it does solve my problems.