### PR TITLE
Improve include, link and render mechanisms

### DIFF
--- a/lib/still/compiler/incremental/node.ex
+++ b/lib/still/compiler/incremental/node.ex
@@ -39,8 +39,8 @@ defmodule Still.Compiler.Incremental.Node do
     GenServer.call(pid, :compile, compilation_timeout())
   end
 
-  def render(pid, data, parent_file) do
-    GenServer.call(pid, {:render, data, parent_file}, compilation_timeout())
+  def render(pid, data, subscriber \\ nil) do
+    GenServer.call(pid, {:render, data, subscriber}, compilation_timeout())
   end
 
   def add_subscription(pid, file) do
@@ -88,9 +88,8 @@ defmodule Still.Compiler.Incremental.Node do
   end
 
   @impl true
-  def handle_call({:render, data, parent_file}, _from, state) do
-    subscribers = [parent_file | state.subscribers] |> Enum.uniq()
-    data = Map.put(data, :current_context, parent_file)
+  def handle_call({:render, data, subscriber}, _from, state) do
+    subscribers = [subscriber | state.subscribers] |> Enum.uniq() |> Enum.reject(&is_nil/1)
     source_file = do_render(data, state)
     ErrorCache.set({:ok, source_file})
 

--- a/lib/still/compiler/view_helpers.ex
+++ b/lib/still/compiler/view_helpers.ex
@@ -17,13 +17,7 @@ defmodule Still.Compiler.ViewHelpers do
 
       @env unquote(variables)
 
-      def include(file) do
-        include(file, %{}, [])
-      end
-
-      def include(file, variables) do
-        include(file, variables, [])
-      end
+      def include(file, variables \\ %{}, opts \\ [])
 
       def include(file, variables, opts) when is_list(variables) do
         include(file, variables |> Enum.into(%{}), opts)

--- a/lib/still/compiler/view_helpers/link.ex
+++ b/lib/still/compiler/view_helpers/link.ex
@@ -28,7 +28,7 @@ defmodule Still.Compiler.ViewHelpers.Link do
 
     case URI.parse(to) do
       %URI{host: nil, scheme: nil, path: path} when not is_nil(path) ->
-        to = add_base_url(to)
+        to = to |> add_base_url() |> modernize()
         {to, opts}
 
       %URI{scheme: scheme} when scheme in ["http", "https"] ->
@@ -47,5 +47,9 @@ defmodule Still.Compiler.ViewHelpers.Link do
     opts
     |> Keyword.put_new(:target, "_blank")
     |> Keyword.put_new(:rel, "noopener noreferrer")
+  end
+
+  defp modernize(path) do
+    path |> String.replace_suffix("index.html", "")
   end
 end

--- a/lib/still/compiler/view_helpers/link_to_css.ex
+++ b/lib/still/compiler/view_helpers/link_to_css.ex
@@ -14,7 +14,7 @@ defmodule Still.Compiler.ViewHelpers.LinkToCSS do
       |> Enum.join(" ")
 
     with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
-         %{output_file: output_file} <- Incremental.Node.render(pid, %{}, env[:input_file]) do
+         %{output_file: output_file} <- Incremental.Node.render(pid, %{}) do
       """
       <link rel="stylesheet" #{link_opts} href=#{UrlFor.render(output_file)} />
       """

--- a/lib/still/compiler/view_helpers/link_to_js.ex
+++ b/lib/still/compiler/view_helpers/link_to_js.ex
@@ -13,7 +13,7 @@ defmodule Still.Compiler.ViewHelpers.LinkToJS do
       |> Enum.join(" ")
 
     with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
-         %{output_file: output_file} <- Incremental.Node.render(pid, %{}, env[:input_file]) do
+         %{output_file: output_file} <- Incremental.Node.render(pid, %{}) do
       """
       <script #{link_opts} src=#{UrlFor.render(output_file)}></script>
       """

--- a/lib/still/compiler/view_helpers/url_for.ex
+++ b/lib/still/compiler/view_helpers/url_for.ex
@@ -5,8 +5,13 @@ defmodule Still.Compiler.ViewHelpers.UrlFor do
   def render(relative_path) do
     relative_path
     |> add_base_url()
+    |> clean_url()
   end
 
   defp add_base_url("/" <> path), do: add_base_url(path)
   defp add_base_url(path), do: get_base_url() <> "/" <> path
+
+  defp clean_url(path) do
+    path |> String.replace_suffix("index.html", "")
+  end
 end

--- a/lib/still/web/router.ex
+++ b/lib/still/web/router.ex
@@ -17,8 +17,8 @@ defmodule Still.Web.Router do
   end
 
   get "*path" do
-    if not send_file(conn, "#{Path.join(get_output_path(), Path.join(path))}/index.html") and
-         not send_file(conn, "#{Path.join(get_output_path(), Path.join(path))}.html") do
+    with :error <- send_file(conn, "#{get_output_path(path)}/index.html"),
+         :error <- send_file(conn, "#{get_output_path(path)}.html") do
       conn
       |> send_resp(404, "File not found")
     end
@@ -29,10 +29,8 @@ defmodule Still.Web.Router do
       conn
       |> put_resp_header("Content-Type", "text/html; charset=UTF-8")
       |> send_file(200, file)
-
-      true
     else
-      false
+      :error
     end
   end
 end

--- a/lib/still/web/router.ex
+++ b/lib/still/web/router.ex
@@ -17,15 +17,22 @@ defmodule Still.Web.Router do
   end
 
   get "*path" do
-    file = "#{Path.join(get_output_path(), Path.join(path))}.html"
+    if not send_file(conn, "#{Path.join(get_output_path(), Path.join(path))}/index.html") and
+         not send_file(conn, "#{Path.join(get_output_path(), Path.join(path))}.html") do
+      conn
+      |> send_resp(404, "File not found")
+    end
+  end
 
+  defp send_file(conn, file) do
     if File.exists?(file) do
       conn
       |> put_resp_header("Content-Type", "text/html; charset=UTF-8")
       |> send_file(200, file)
+
+      true
     else
-      conn
-      |> send_resp(404, "File not found")
+      false
     end
   end
 end

--- a/test/still/compiler/view_helpers_test.exs
+++ b/test/still/compiler/view_helpers_test.exs
@@ -4,7 +4,7 @@ defmodule Still.Compiler.ViewHelpersTest do
   alias Still.Compiler.ViewHelpers
 
   defmodule View do
-    use ViewHelpers
+    use ViewHelpers, input_file: "some_file.slime"
   end
 
   describe "include/2" do
@@ -28,7 +28,7 @@ defmodule Still.Compiler.ViewHelpersTest do
 
       View.include(file)
 
-      assert_receive {_, {:add_subscription, file}}
+      assert_receive {_, {:add_subscription, file}}, 200
     end
   end
 end

--- a/test/still/compiler/view_helpers_test.exs
+++ b/test/still/compiler/view_helpers_test.exs
@@ -4,7 +4,7 @@ defmodule Still.Compiler.ViewHelpersTest do
   alias Still.Compiler.ViewHelpers
 
   defmodule View do
-    use ViewHelpers, input_file: "some_file.slime"
+    use ViewHelpers, input_file: "about.slime"
   end
 
   describe "include/2" do


### PR DESCRIPTION
This change accomplishes many things, but they are all interconnected:

1. You can now use keyword lists in includes: `= include "somefile.slime", variable: 1`.
2. You can include/link to a file but not subscribe to its changes. For instance, I want to link to a CSS file from an HTML file, but I don't want to recompile the HTML when the CSS file changes.
3. URLs are now modern. Accessing `/blog/some-article` will first look for the file ``/blog/some-article.html` but also for ``/blog/some-article/index.html`. 