### PR TITLE
Everything is a preprocessor!

### DIFF
--- a/lib/still/compiler/file/content.ex
+++ b/lib/still/compiler/file/content.ex
@@ -1,84 +1,16 @@
 defmodule Still.Compiler.File.Content do
   require Logger
 
-  alias Still.Compiler.Incremental
   alias Still.SourceFile
-  alias Still.Compiler.PreprocessorError
+  alias Still.Preprocessor
 
-  @spec render(SourceFile.t(), [module()]) :: SourceFile.t()
-  def render(file, preprocessors) do
-    render_template(file, preprocessors)
-    |> append_layout()
+  @spec render(SourceFile.t()) :: SourceFile.t()
+  def render(file) do
+    Preprocessor.run(file)
   end
 
-  @spec compile(SourceFile.t(), [module()]) :: SourceFile.t()
-  def compile(file, preprocessors) do
-    render(file, preprocessors)
-    |> append_development_layout()
-  end
-
-  defp append_layout(
-         %{
-           content: children,
-           input_file: input_file,
-           variables: %{layout: layout_file} = variables
-         } = file
-       ) do
-    layout_variables =
-      variables
-      |> Map.drop([:tag, :layout, :permalink, :input_file])
-      |> Map.put(:children, children)
-
-    %{content: content} =
-      layout_file
-      |> Incremental.Registry.get_or_create_file_process()
-      |> Incremental.Node.render(layout_variables, input_file)
-
-    %SourceFile{file | content: content}
-  end
-
-  defp append_layout(file), do: file
-
-  defp append_development_layout(%{extension: ".html", content: content} = file) do
-    if Application.get_env(:still, :dev_layout, false) do
-      %{content: content} = Still.Compiler.File.DevLayout.wrap(content)
-
-      %{file | content: content}
-    else
-      file
-    end
-  end
-
-  defp append_development_layout(file), do: file
-
-  defp render_template(file, []) do
-    file
-  end
-
-  defp render_template(file, [preprocessor | remaining_preprocessors]) do
-    preprocessor.run(file)
-    |> render_template(remaining_preprocessors)
-  catch
-    :error, %{description: description} ->
-      raise PreprocessorError,
-        message: description,
-        preprocessor: preprocessor,
-        remaining_preprocessors: remaining_preprocessors,
-        source_file: file,
-        stacktrace: __STACKTRACE__
-
-    :error, e ->
-      case e do
-        %PreprocessorError{} ->
-          raise e
-
-        _ ->
-          raise PreprocessorError,
-            message: inspect(e),
-            preprocessor: preprocessor,
-            remaining_preprocessors: remaining_preprocessors,
-            source_file: file,
-            stacktrace: __STACKTRACE__
-      end
+  @spec compile(SourceFile.t()) :: SourceFile.t()
+  def compile(file) do
+    render(%{file | run_type: :compile})
   end
 end

--- a/lib/still/preprocessor/add_content.ex
+++ b/lib/still/preprocessor/add_content.ex
@@ -1,0 +1,18 @@
+defmodule Still.Preprocessor.AddContent do
+  alias Still.{Preprocessor, SourceFile}
+
+  import Still.Utils
+
+  use Preprocessor
+
+  require Logger
+
+  @impl true
+  def render(%{content: content} = file) when is_nil(content) do
+    with {:ok, content} <- File.read(get_input_path(file)) do
+      %SourceFile{file | content: content}
+    end
+  end
+
+  def render(file), do: file
+end

--- a/lib/still/preprocessor/add_layout.ex
+++ b/lib/still/preprocessor/add_layout.ex
@@ -1,0 +1,32 @@
+defmodule Still.Preprocessor.AddLayout do
+  alias Still.Preprocessor
+  alias Still.Compiler.Incremental
+
+  use Preprocessor
+
+  require Logger
+
+  @impl true
+  def render(
+        %{
+          content: children,
+          input_file: input_file,
+          variables: %{layout: layout_file} = variables
+        } = file
+      )
+      when not is_nil(layout_file) do
+    layout_variables =
+      variables
+      |> Map.drop([:tag, :layout, :permalink, :input_file])
+      |> Map.put(:children, children)
+
+    %{content: content} =
+      layout_file
+      |> Incremental.Registry.get_or_create_file_process()
+      |> Incremental.Node.render(layout_variables, input_file)
+
+    %{file | content: content}
+  end
+
+  def render(file), do: file
+end

--- a/lib/still/preprocessor/save.ex
+++ b/lib/still/preprocessor/save.ex
@@ -1,0 +1,46 @@
+defmodule Still.Preprocessor.Save do
+  alias Still.Preprocessor
+  alias Still.Compiler.Collections
+
+  use Preprocessor
+
+  import Still.Utils
+
+  require Logger
+
+  @impl true
+  def render(file = %{input_file: input_file, run_type: :compile}) do
+    file = %{content: content} = file |> append_development_layout()
+
+    with new_file_path <- get_output_path(file),
+         _ <- File.mkdir_p!(Path.dirname(new_file_path)),
+         :ok <- File.write(new_file_path, content),
+         _ <- Collections.add(file) do
+      Logger.info("Compiled #{input_file}")
+      {:ok, file}
+    else
+      msg = {:error, :preprocessor_not_found} ->
+        msg
+
+      msg ->
+        Logger.error("Failed to compile #{input_file}")
+        msg
+    end
+
+    file
+  end
+
+  def render(file), do: file
+
+  defp append_development_layout(%{extension: ".html", content: content} = file) do
+    if Application.get_env(:still, :dev_layout, false) do
+      %{content: content} = Still.Compiler.File.DevLayout.wrap(content)
+
+      %{file | content: content}
+    else
+      file
+    end
+  end
+
+  defp append_development_layout(file), do: file
+end

--- a/lib/still/source_file.ex
+++ b/lib/still/source_file.ex
@@ -13,11 +13,13 @@ defmodule Still.SourceFile do
     :input_file,
     :output_file,
     content: nil,
+    variables: %{},
     extension: nil,
-    variables: %{}
+    run_type: :render
   ]
 
   @type t :: %__MODULE__{
+          run_type: :render | :compile,
           content: binary() | nil,
           extension: binary() | nil,
           input_file: binary(),

--- a/test/still/compiler/collections_test.exs
+++ b/test/still/compiler/collections_test.exs
@@ -25,7 +25,7 @@ defmodule Still.Compiler.CollectionsTest do
       with_mock Registry, get_or_create_file_process: fn _ -> file_pid end do
         file = %SourceFile{input_file: "file", variables: %{tag: ["post"]}}
         Collections.add(file)
-        Collections.get("post", "file")
+        Collections.get("post", "about.slime")
 
         Collections.add(file)
 

--- a/test/still/compiler/file/content_test.exs
+++ b/test/still/compiler/file/content_test.exs
@@ -13,12 +13,14 @@ defmodule Still.Compiler.File.ContentTest do
     AddLayout
   ]
 
+  setup do
+    Application.put_env(:still, :preprocessors, %{
+      ".slime" => @preprocessors
+    })
+  end
+
   describe "compile" do
     test "compiles a file" do
-      Application.put_env(:still, :preprocessors, %{
-        ".slime" => @preprocessors
-      })
-
       file = "index.slime"
       content = "p Hello"
 
@@ -27,10 +29,6 @@ defmodule Still.Compiler.File.ContentTest do
     end
 
     test "returns the metadata" do
-      Application.put_env(:still, :preprocessors, %{
-        ".slime" => @preprocessors
-      })
-
       file = "index.slime"
 
       content = """
@@ -48,10 +46,6 @@ defmodule Still.Compiler.File.ContentTest do
     end
 
     test "supports layout" do
-      Application.put_env(:still, :preprocessors, %{
-        ".slime" => @preprocessors
-      })
-
       file = "index.slime"
 
       content = """
@@ -79,7 +73,7 @@ defmodule Still.Compiler.File.ContentTest do
 
       assert_raise PreprocessorError, "undefined function test/1", fn ->
         %SourceFile{input_file: file, content: content}
-        |> Content.compile(@preprocessors)
+        |> Content.compile()
       end
     end
   end

--- a/test/still/compiler/file/content_test.exs
+++ b/test/still/compiler/file/content_test.exs
@@ -4,22 +4,33 @@ defmodule Still.Compiler.File.ContentTest do
   alias Still.Compiler.File.Content
   alias Still.Compiler.PreprocessorError
   alias Still.SourceFile
+  alias Still.Preprocessor.{Frontmatter, Slime, AddLayout, AddContent}
 
   @preprocessors [
-    Still.Preprocessor.Frontmatter,
-    Still.Preprocessor.Slime
+    AddContent,
+    Frontmatter,
+    Slime,
+    AddLayout
   ]
 
   describe "compile" do
     test "compiles a file" do
+      Application.put_env(:still, :preprocessors, %{
+        ".slime" => @preprocessors
+      })
+
       file = "index.slime"
       content = "p Hello"
 
       assert %{content: "<p>Hello</p>", input_file: file} =
-               Content.compile(%SourceFile{input_file: file, content: content}, @preprocessors)
+               Content.compile(%SourceFile{input_file: file, content: content})
     end
 
     test "returns the metadata" do
+      Application.put_env(:still, :preprocessors, %{
+        ".slime" => @preprocessors
+      })
+
       file = "index.slime"
 
       content = """
@@ -33,10 +44,14 @@ defmodule Still.Compiler.File.ContentTest do
       """
 
       assert %{content: "<p>Hello</p>", variables: %{hello: "world", tags: ["post", "article"]}} =
-               Content.compile(%SourceFile{input_file: file, content: content}, @preprocessors)
+               Content.compile(%SourceFile{input_file: file, content: content})
     end
 
     test "supports layout" do
+      Application.put_env(:still, :preprocessors, %{
+        ".slime" => @preprocessors
+      })
+
       file = "index.slime"
 
       content = """
@@ -46,8 +61,7 @@ defmodule Still.Compiler.File.ContentTest do
       p Hello
       """
 
-      %{content: content} =
-        Content.compile(%SourceFile{input_file: file, content: content}, @preprocessors)
+      %{content: content} = Content.compile(%SourceFile{input_file: file, content: content})
 
       assert String.starts_with?(content, "<!DOCTYPE html><html><head><title>Still</title>")
       assert String.ends_with?(content, "<body><p>Hello</p></body></html>")

--- a/test/still/compiler/file_test.exs
+++ b/test/still/compiler/file_test.exs
@@ -2,6 +2,21 @@ defmodule Still.Compiler.FileTest do
   use Still.Case, async: false
 
   alias Still.Compiler
+  alias Still.Preprocessor.{Frontmatter, Slime, OutputPath, Save, AddContent}
+
+  setup do
+    Application.put_env(:still, :preprocessors, %{
+      ".slime" => [
+        AddContent,
+        Frontmatter,
+        Slime,
+        OutputPath,
+        Save
+      ]
+    })
+
+    :ok
+  end
 
   describe "compile" do
     test "compiles a slime template" do

--- a/test/still/compiler/incremental/node_test.exs
+++ b/test/still/compiler/incremental/node_test.exs
@@ -2,14 +2,33 @@ defmodule Still.Compiler.Incremental.NodeTest do
   use Still.Case, async: false
 
   alias Still.Compiler.Incremental.{Registry, Node}
+  alias Still.Compiler.CompilationStage
+
+  alias Still.Preprocessor.{Frontmatter, Slime, AddLayout, AddContent, Save, OutputPath}
+
+  @preprocessors [
+    AddContent,
+    Frontmatter,
+    Slime,
+    AddLayout,
+    OutputPath,
+    Save
+  ]
+
+  setup do
+    Application.put_env(:still, :preprocessors, %{
+      ".slime" => @preprocessors
+    })
+  end
 
   describe "process" do
     test "compiles a file" do
-      pid = Registry.get_or_create_file_process("index.slime")
+      CompilationStage.subscribe()
+      pid = Registry.get_or_create_file_process("about.slime")
 
       Node.compile(pid)
 
-      assert File.exists?(get_output_path("index.html"))
+      assert File.exists?(get_output_path("about.html"))
     end
 
     test "notifies subscribers" do

--- a/test/still/preprocessor_test.exs
+++ b/test/still/preprocessor_test.exs
@@ -2,7 +2,16 @@ defmodule Still.PreprocessorTest do
   use Still.Case, async: false
 
   alias Still.{Preprocessor, SourceFile}
-  alias Still.Preprocessor.{EEx, CSSMinify, OutputPath, URLFingerprinting}
+
+  alias Still.Preprocessor.{
+    EEx,
+    CSSMinify,
+    OutputPath,
+    URLFingerprinting,
+    AddContent,
+    AddLayout,
+    Save
+  }
 
   defmodule TestPreprocessorWithExt do
     use Preprocessor
@@ -26,7 +35,7 @@ defmodule Still.PreprocessorTest do
 
   describe "for/1" do
     test "returns the preprocessors for a source_file" do
-      assert {:ok, [EEx, CSSMinify, OutputPath, URLFingerprinting]} ==
+      assert {:ok, [AddContent, EEx, CSSMinify, OutputPath, URLFingerprinting, AddLayout, Save]} ==
                %SourceFile{input_file: "app.css"}
                |> Preprocessor.for()
     end


### PR DESCRIPTION
This change goes towards our initial intention of making everything a preprocessor. With this change, we can combine the preprocessors to any scenario. For instance, on a new image processing preprocessor I'm taking out the "AddContent" preprocessor because I don't want to read the content in Elixir, I want to send the file directly to Rust where it will be read as a stream. In the same scenario, I don't want to save the file, because it will be saved by rust. I think this design really is a step forward.